### PR TITLE
Fix passthrough of output; Add flag that disables passthrough.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ console.log(stderr); // => 'bar\n'
 
 ## Suppressing output during recording
 
-If you want to record the stdstreams and suppress their outputs, cass record with `false` as parameter:
+If you want to record the stdstreams and suppress their outputs, call record with `false` as parameter:
 
 ```javascript
 const stop = record(false);

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ console.log(stdout); // => 'foo\n'
 console.log(stderr); // => 'bar\n'
 ```
 
+## Suppressing output during recording
+
+If you want to record the stdstreams and suppress their outputs, cass record with `false` as parameter:
+
+```javascript
+const stop = record(false);
+
+console.log('foo'); // => does not produce output
+
+const { stdout } = stop();
+
+console.log(stdout); // => 'foo\n'
+```
+
 ## Running the build
 
 To build this module use [roboter](https://www.npmjs.com/package/roboter).

--- a/lib/record.ts
+++ b/lib/record.ts
@@ -1,53 +1,37 @@
 /* eslint-disable func-style, @typescript-eslint/unbound-method */
-const record = function (): (() => ({ stdout: string; stderr: string })) {
+const record = function (passThrough = true): (() => ({ stdout: string; stderr: string })) {
   const oldStderrWrite = process.stderr.write.bind(process.stderr),
         oldStdoutWrite = process.stdout.write.bind(process.stdout);
 
   let stderr = '',
       stdout = '';
 
-  function collectStderr (text: string | Uint8Array, encoding?: string | ((err?: Error | null) => void), cb?: (err?: Error | null) => void): boolean {
+  const collectStderr = (text: any, encoding?: any, cb?: any): boolean => {
     stderr += text.toString();
 
-    if (typeof text === 'object') {
-      if (typeof encoding === 'string') {
-        throw new Error('Invalid operation.');
-      }
-
-      return oldStderrWrite(text, encoding);
-    }
-
-    if (typeof encoding === 'function') {
-      throw new Error('Invalid operation.');
+    if (!passThrough) {
+      return true;
     }
 
     return oldStderrWrite(text, encoding, cb);
-  }
+  };
 
-  function collectStdout (text: string | Uint8Array, encoding?: string | ((err?: Error | null) => void), cb?: (err?: Error | null) => void): boolean {
+  const collectStdout = (text: any, encoding?: any, cb?: any): boolean => {
     stdout += text.toString();
 
-    if (typeof text === 'object') {
-      if (typeof encoding === 'string') {
-        throw new Error('Invalid operation.');
-      }
-
-      return oldStdoutWrite(text, encoding);
-    }
-
-    if (typeof encoding === 'function') {
-      throw new Error('Invalid operation.');
+    if (!passThrough) {
+      return true;
     }
 
     return oldStdoutWrite(text, encoding, cb);
-  }
+  };
 
   process.stderr.write = collectStderr;
   process.stdout.write = collectStdout;
 
   const stop = function (): ({ stdout: string; stderr: string }) {
-    process.stderr.write = oldStderrWrite.bind(process.stderr);
-    process.stdout.write = oldStdoutWrite.bind(process.stdout);
+    process.stderr.write = oldStderrWrite;
+    process.stdout.write = oldStdoutWrite;
 
     return { stdout, stderr };
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,42 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -188,6 +224,12 @@
       "version": "12.7.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
       "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.13.tgz",
+      "integrity": "sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==",
       "dev": true
     },
     "@types/unist": {
@@ -347,6 +389,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-includes": {
@@ -1789,6 +1837,12 @@
       "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
       "dev": true
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1864,6 +1918,12 @@
         "array-includes": "^3.0.3",
         "object.assign": "^4.1.0"
       }
+    },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
     },
     "lcid": {
       "version": "2.0.0",
@@ -1968,6 +2028,12 @@
       "requires": {
         "chalk": "^2.0.1"
       }
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.3",
@@ -2363,6 +2429,19 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -2680,6 +2759,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -3067,6 +3155,21 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "sinon": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.4.2.tgz",
+      "integrity": "sha512-pY5RY99DKelU3pjNxcWo6XqeB1S118GBcVIIdDi6V+h6hevn1izcg2xv1hTHW/sViRXU7sUOxt4wTUJ3gsW2CQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3407,6 +3510,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "12.7.4",
+    "@types/sinon": "7.0.13",
     "assertthat": "4.0.2",
-    "roboter": "7.1.5"
+    "roboter": "7.1.5",
+    "sinon": "7.4.2"
   },
   "repository": {
     "type": "git",

--- a/test/unit/recordTests.ts
+++ b/test/unit/recordTests.ts
@@ -1,5 +1,6 @@
 import assert from 'assertthat';
 import record from '../../lib/record';
+import sinon from 'sinon';
 
 suite('record', (): void => {
   test('is a function.', async (): Promise<void> => {
@@ -18,7 +19,10 @@ suite('record', (): void => {
   });
 
   suite('stdout', (): void => {
-    test('records a single call to console.log.', async (): Promise<void> => {
+    test('records a single call to console.log and passes it through.', async (): Promise<void> => {
+      const spyStdout = sinon.spy(process.stdout, 'write');
+      const spyStderr = sinon.spy(process.stderr, 'write');
+
       const stop = record();
 
       /* eslint-disable no-console */
@@ -29,9 +33,16 @@ suite('record', (): void => {
 
       assert.that(stdout).is.equalTo('foo\n');
       assert.that(stderr).is.equalTo('');
+
+      assert.that(spyStdout.callCount).is.equalTo(1);
+      assert.that(spyStdout.firstCall.args[0]).is.equalTo('foo\n');
+      assert.that(spyStderr.callCount).is.equalTo(0);
     });
 
     test('records multiple calls to console.log.', async (): Promise<void> => {
+      const spyStdout = sinon.spy(process.stdout, 'write');
+      const spyStderr = sinon.spy(process.stderr, 'write');
+
       const stop = record();
 
       /* eslint-disable no-console */
@@ -43,9 +54,17 @@ suite('record', (): void => {
 
       assert.that(stdout).is.equalTo('foo\nbar\n');
       assert.that(stderr).is.equalTo('');
+
+      assert.that(spyStdout.callCount).is.equalTo(2);
+      assert.that(spyStdout.firstCall.args[0]).is.equalTo('foo\n');
+      assert.that(spyStdout.secondCall.args[0]).is.equalTo('bar\n');
+      assert.that(spyStderr.callCount).is.equalTo(0);
     });
 
     test('accepts write with a single parameter.', async (): Promise<void> => {
+      const spyStdout = sinon.spy(process.stdout, 'write');
+      const spyStderr = sinon.spy(process.stderr, 'write');
+
       const stop = record();
 
       process.stdout.write('foo');
@@ -53,11 +72,18 @@ suite('record', (): void => {
       const { stdout } = stop();
 
       assert.that(stdout).is.equalTo('foo');
+
+      assert.that(spyStdout.callCount).is.equalTo(1);
+      assert.that(spyStdout.firstCall.args[0]).is.equalTo('foo');
+      assert.that(spyStderr.callCount).is.equalTo(0);
     });
   });
 
   suite('stderr', (): void => {
     test('records a single call to console.error.', async (): Promise<void> => {
+      const spyStdout = sinon.spy(process.stdout, 'write');
+      const spyStderr = sinon.spy(process.stderr, 'write');
+
       const stop = record();
 
       /* eslint-disable no-console */
@@ -68,9 +94,16 @@ suite('record', (): void => {
 
       assert.that(stdout).is.equalTo('');
       assert.that(stderr).is.equalTo('foo\n');
+
+      assert.that(spyStdout.callCount).is.equalTo(0);
+      assert.that(spyStderr.callCount).is.equalTo(1);
+      assert.that(spyStderr.firstCall.args[0]).is.equalTo('foo\n');
     });
 
     test('records multiple calls to console.error.', async (): Promise<void> => {
+      const spyStdout = sinon.spy(process.stdout, 'write');
+      const spyStderr = sinon.spy(process.stderr, 'write');
+
       const stop = record();
 
       /* eslint-disable no-console */
@@ -82,9 +115,17 @@ suite('record', (): void => {
 
       assert.that(stdout).is.equalTo('');
       assert.that(stderr).is.equalTo('foo\nbar\n');
+
+      assert.that(spyStdout.callCount).is.equalTo(0);
+      assert.that(spyStderr.callCount).is.equalTo(2);
+      assert.that(spyStderr.firstCall.args[0]).is.equalTo('foo\n');
+      assert.that(spyStderr.secondCall.args[0]).is.equalTo('bar\n');
     });
 
     test('accepts write with a single parameter.', async (): Promise<void> => {
+      const spyStdout = sinon.spy(process.stdout, 'write');
+      const spyStderr = sinon.spy(process.stderr, 'write');
+
       const stop = record();
 
       process.stderr.write('foo');
@@ -92,6 +133,54 @@ suite('record', (): void => {
       const { stderr } = stop();
 
       assert.that(stderr).is.equalTo('foo');
+
+      assert.that(spyStdout.callCount).is.equalTo(0);
+      assert.that(spyStderr.callCount).is.equalTo(1);
+      assert.that(spyStderr.firstCall.args[0]).is.equalTo('foo');
+    });
+  });
+
+  suite('disable passthrough', (): void => {
+    suite('stdout', (): void => {
+      test('records output and does not let it through.', async (): Promise<void> => {
+        const spyStdout = sinon.spy(process.stdout, 'write');
+        const spyStderr = sinon.spy(process.stderr, 'write');
+
+        const stop = record(false);
+
+        /* eslint-disable no-console */
+        console.log('foo');
+        /* eslint-enable no-console */
+
+        const { stdout, stderr } = stop();
+
+        assert.that(stdout).is.equalTo('foo\n');
+        assert.that(stderr).is.equalTo('');
+
+        assert.that(spyStdout.callCount).is.equalTo(0);
+        assert.that(spyStderr.callCount).is.equalTo(0);
+      });
+    });
+
+    suite('stderr', (): void => {
+      test('records output and does not let it through.', async (): Promise<void> => {
+        const spyStdout = sinon.spy(process.stdout, 'write');
+        const spyStderr = sinon.spy(process.stderr, 'write');
+
+        const stop = record(false);
+
+        /* eslint-disable no-console */
+        console.error('foo');
+        /* eslint-enable no-console */
+
+        const { stdout, stderr } = stop();
+
+        assert.that(stdout).is.equalTo('');
+        assert.that(stderr).is.equalTo('foo\n');
+
+        assert.that(spyStdout.callCount).is.equalTo(0);
+        assert.that(spyStderr.callCount).is.equalTo(0);
+      });
     });
   });
 });


### PR DESCRIPTION
When writing record-stdstreams v2.0.0 we decided to let all output pass through by default.
However I did not explicitly test that, since I thought it was too complicated. Turns out, this led to a bug which would not let the output pass through _and_ testing for it is way easier than I thought.

So I extended the tests to spy on `process.stdout/stderr.write` and verify whether output arrived there.

The bug was in the collector functions which would call the old bound write functions and throw exceptions when the given parameter types didn't match the expected types. This was annoying the first time around since TypeScript forced me to do stupid type checks manually. Since these check are basically useless at that point and since our outward API is not affected by this, I changed the signatures of the collector functions to accept `any` for all parameters and just pass the parameters through to the old write functions.

As to why we didn't notice this bug earlier: `console.log` does [silent error handling](https://github.com/nodejs/node/blob/master/lib/internal/console/constructor.js#L236) when `process.stdout/stderr.write` throws an exception.

Also I added a new feature: `record` now takes a boolean parameter which configures whether output should pass through or not.